### PR TITLE
updated for pimcore 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,6 @@ Base of each export is an export configuration which is described below.
 
 ![export-toolkit](/src/Elements/Bundle/ExportToolkitBundle/doc/images/export-toolkit.png)
 
-## Migration notes from Pimcore 4 to 5
-
-* migrate the config format to version 2.0 (see migrate-2.0.php)
-* move the plugin's configuration file from website/var/plugins/ExportToolkit to 
-            var/config/ExportToolkit/config.php
-* Please note that the namespaces have been changed!!!
-** Change ExportToolkit\* to Elements\Bundle\ExportToolkitBundle\*
-** This also affects your export configurations. Check export-toolkit-configurations.php
-* Be aware that this also affects your custom implementations (interpreters, getters and so so on). So you might have to change code. 
-* adapt your crontab 
-* The default output directory also has changed (used every time you don't specify a output file) to var/tmp/ExportToolkit
-
 ### Export Configuration
 
 An export configuration is a container to configure a specific export of pimcore objects.
@@ -123,8 +111,22 @@ Each attribute cluster has one or more attributes. An attribute is one data entr
    * translator: possible values are admin or website for using admin or website translations to translate the value
    
   
+## Running with Pimcore < 5.4
+With Pimcore 5.4 the location of static Pimcore files like icons has changed. In order to make this bundle work 
+with Pimcore < 5.4, please add following rewrite rule to your `.htaccess`.
+```
+    # rewrite rule for pre pimcore 5.4 core static files
+    RewriteRule ^bundles/pimcoreadmin/(.*) /pimcore/static6/$1 [PT,L]
+``` 
 
+## Migration notes from Pimcore 4 to 5
 
-
-
-
+* migrate the config format to version 2.0 (see migrate-2.0.php)
+* move the plugin's configuration file from website/var/plugins/ExportToolkit to 
+            var/config/ExportToolkit/config.php
+* Please note that the namespaces have been changed!!!
+** Change ExportToolkit\* to Elements\Bundle\ExportToolkitBundle\*
+** This also affects your export configurations. Check export-toolkit-configurations.php
+* Be aware that this also affects your custom implementations (interpreters, getters and so so on). So you might have to change code. 
+* adapt your crontab 
+* The default output directory also has changed (used every time you don't specify a output file) to var/tmp/ExportToolkit

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "elements/export-toolkit-bundle",
   "type": "pimcore-bundle",
   "require": {
-      "pimcore/core-version": ">=5.2.0 <5.4",
+      "pimcore/core-version": ">=5.2.0 <5.5",
       "elements/process-manager-bundle": "~2.2"
   },
   "autoload": {

--- a/src/Elements/Bundle/ExportToolkitBundle/Resources/public/css/example.css
+++ b/src/Elements/Bundle/ExportToolkitBundle/Resources/public/css/example.css
@@ -1,21 +1,21 @@
 .plugin_exporttoolkit_configpanel, .plugin_exporttoolkit_config {
-    background: url(/pimcore/static6/img/icon/database_table.png) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/icon/database_table.png) center center no-repeat !important;
 }
 
 .plugin_exporttoolkit_clear_config_cache {
-    background: url(/pimcore/static6/img/icon/lightning.png) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/icon/lightning.png) center center no-repeat !important;
 }
 
 .plugin_exporttoolkit_start {
-    background: url(/pimcore/static6/img/icon/cog_go.png) no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/icon/cog_go.png) no-repeat !important;
 
 }
 #pimcore_menu_exporttoolkit{
-    background-image: url(/pimcore/static6/img/flat-color-icons/go.svg) !important;
+    background-image: url(/bundles/pimcoreadmin/img/flat-color-icons/go.svg) !important;
 }
 
 .plugin_exporttoolkit_status {
-    background: url(/pimcore/static6/img/icon/cog_go.png) no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/icon/cog_go.png) no-repeat !important;
 }
 
 

--- a/src/Elements/Bundle/ExportToolkitBundle/Resources/public/js/exporttoolkit/config/item.js
+++ b/src/Elements/Bundle/ExportToolkitBundle/Resources/public/js/exporttoolkit/config/item.js
@@ -393,7 +393,7 @@ pimcore.plugin.exporttoolkit.config.Item = Class.create(pimcore.element.abstract
             items: [
                 {
                     tooltip: t('plugin_exporttoolkit_configpanel_item_attributeAdvanced'),
-                    icon: "/pimcore/static6/img/icon/cog_edit.png",
+                    icon: "/bundles/pimcoreadmin/img/icon/cog_edit.png",
                     handler: function (grid, rowIndex) {
                         var data = grid.getStore().getAt(rowIndex);
                         var dialog = new pimcore.plugin.exporttoolkit.config.AttributeConfig(this.updateData, data, grid);
@@ -409,7 +409,7 @@ pimcore.plugin.exporttoolkit.config.Item = Class.create(pimcore.element.abstract
             items: [
                 {
                     tooltip: t('up'),
-                    icon: "/pimcore/static6/img/icon/arrow_up.png",
+                    icon: "/bundles/pimcoreadmin/img/icon/arrow_up.png",
                     handler: function (grid, rowIndex) {
                         if(rowIndex > 0) {
                             var rec = grid.getStore().getAt(rowIndex);
@@ -426,7 +426,7 @@ pimcore.plugin.exporttoolkit.config.Item = Class.create(pimcore.element.abstract
             items: [
                 {
                     tooltip: t('down'),
-                    icon: "/pimcore/static6/img/icon/arrow_down.png",
+                    icon: "/bundles/pimcoreadmin/img/icon/arrow_down.png",
                     handler: function (grid, rowIndex) {
                         if(rowIndex < (grid.getStore().getCount()-1)) {
                             var rec = grid.getStore().getAt(rowIndex);
@@ -444,7 +444,7 @@ pimcore.plugin.exporttoolkit.config.Item = Class.create(pimcore.element.abstract
             items: [
                 {
                     tooltip: t('remove'),
-                    icon: "/pimcore/static6/img/icon/cross.png",
+                    icon: "/bundles/pimcoreadmin/img/icon/cross.png",
                     handler: function (grid, rowIndex) {
                         grid.getStore().removeAt(rowIndex);
                     }.bind(this)


### PR DESCRIPTION
## For running with Pimcore < 5.4
With Pimcore 5.4 the location of static Pimcore files like icons has changed. In order to make this bundle work with Pimcore < 5.4, please add following rewrite rule to your `.htaccess`.
```
    # rewrite rule for pre pimcore 5.4 core static files
    RewriteRule ^bundles/pimcoreadmin/(.*) /pimcore/static6/$1 [PT,L]
``` 