### PR TITLE
fix(Worker): prevent Monolog error

### DIFF
--- a/src/Elements/Bundle/ExportToolkitBundle/ExportService/Worker.php
+++ b/src/Elements/Bundle/ExportToolkitBundle/ExportService/Worker.php
@@ -184,7 +184,7 @@ class Worker
 
                             $clusterInterpreter->setData($object, $name, $value);
                         } catch (\Exception $e) {
-                            Logger::err('Exception in ExportService: ' . $e->getMessage(), $e);
+                            Logger::err('Exception in ExportService: ' . $e->getMessage());
                         }
                     }
                 }


### PR DESCRIPTION
Current behavior in Pimcore 6 raises the following error while executing export-toolkit:export command:
```bash
# sudo -u www-data /srv/www/htdocs/bin/console export-toolkit:export --config-name="KilyCMS"
[2020-05-13 01:06:52] app.NOTICE:  
[2020-05-13 01:06:52] app.INFO: export-toolkit-KilyCMS 
[2020-05-13 01:06:52] app.NOTICE: Setting up export KilyCMS 
[2020-05-13 01:06:52] app.NOTICE: Starting Exporting Data 
[2020-05-13 01:06:52] app.NOTICE: Processing Product 1 from 1 (0 remaining) 
[2020-05-13 01:06:52] app.DEBUG: Updating object 2 
[2020-05-13 01:06:52] app.NOTICE: ERROR:TypeError: Argument 2 passed to Monolog\Logger::error() must be of the type array, object given, called in /srv/www/htdocs/vendor/pimcore/pimcore/lib/Logger.php on line 30 and defined in /srv/www/htdocs/vendor/monolog/monolog/src/Monolog/Logger.php:710 Stack trace: #0 /srv/www/htdocs/vendor/pimcore/pimcore/lib/Logger.php(30): Monolog\Logger->error() #1 /srv/www/htdocs/vendor/pimcore/pimcore/lib/Logger.php(98): Pimcore\Logger::log() #2 /srv/www/htdocs/vendor/elements/export-toolkit-bundle/src/Elements/Bundle/ExportToolkitBundle/ExportService/Worker.php(187): Pimcore\Logger::err() #3 /srv/www/htdocs/vendor/elements/export-toolkit-bundle/src/Elements/Bundle/ExportToolkitBundle/ExportService.php(146): Elements\Bundle\ExportToolkitBundle\ExportService\Worker->updateExport() #4 /srv/www/htdocs/vendor/elements/export-toolkit-bundle/src/Elements/Bundle/ExportToolkitBundle/ExportService.php(90): Elements\Bundle\ExportToolkitBundle\ExportService->doExecuteExport() #5 /srv/www/htdocs/vendor/elements/export-toolkit-bundle/src/Elements/Bundle/ExportToolkitBundle/Command/ExportCommand.php(56): Elements\Bundle\ExportToolkitBundle\ExportService->executeExport() #6 /srv/www/htdocs/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php(255): Elements\Bundle\ExportToolkitBundle\Command\ExportCommand->execute() #7 /srv/www/htdocs/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php(1019): Symfony\Component\Console\Command\Command->run() #8 /srv/www/htdocs/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php(97): Symfony\Component\Console\Application->doRunCommand() #9 /srv/www/htdocs/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php(271): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() #10 /srv/www/htdocs/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php(83): Symfony\Component\Console\Application->doRun() #11 /srv/www/htdocs/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php(147): Symfony\Bundle\FrameworkBundle\Console\Application->doRun() #12 /srv/www/htdocs/bin/console(36): Symfony\Component\Console\Application->run() #13 {main}Processing Product 1 from 1 (0 remaining) 

In Logger.php line 710:
                                                                                                                                                                    
  Argument 2 passed to Monolog\Logger::error() must be of the type array, object given, called in /srv/www/htdocs/vendor/pimcore/pimcore/lib/Logger.php on line 30
```
This patch fixes it.