### PR TITLE
Fix #4 - Unable to execute command on pimcore 6

### DIFF
--- a/src/Elements/Bundle/ExportToolkitBundle/Resources/config/services.yml
+++ b/src/Elements/Bundle/ExportToolkitBundle/Resources/config/services.yml
@@ -1,4 +1,8 @@
 services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
     exporttoolkit.event_listener:
         class: Elements\Bundle\ExportToolkitBundle\EventListener\ExportListener
 #        lazy: true
@@ -10,3 +14,6 @@ services:
 
     exporttoolkit.exportservice:
         class: Elements\Bundle\ExportToolkitBundle\ExportService
+
+    Elements\Bundle\ExportToolkitBundle\Command\:
+        resource: '../../Command'


### PR DESCRIPTION
In order for command to appear in Symfony console, it needs to be explicitly registered in services.yml. Based on @ab-kily solution, I decided to modify it a little bit and auto-register the whole command directory to support future commands, if any.