### PR TITLE
Update services.yml

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -16,6 +16,8 @@ services:
 
     Elements\Bundle\ExportToolkitBundle\Command\:
         resource: '../../Command'
+        arguments:
+            $name: 'export_name' 
 
     Elements\Bundle\ExportToolkitBundle\Controller\:
         resource: '../../Controller'


### PR DESCRIPTION
Declaring value for name in Export Command to handle Symfony\Component\DependencyInjection\Exception\RuntimeException {#19537
  #message: "Cannot autowire service "Elements\Bundle\ExportToolkitBundle\Command\ExportCommand": argument "$name" of method "__construct()" is type-hinted "string", you should configure its value explicitly."