### PR TITLE
Pimcore 11 support

### DIFF
--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -30,10 +30,13 @@ class ExportCommand extends AbstractCommand
 
     protected LockFactory $lockFactory;
 
-    public function __construct(string $name = null, LockFactory $lockFactory)
+    protected ExportService $exportService;
+
+    public function __construct(LockFactory $lockFactory, ExportService $exportService, string $name = null)
     {
         parent::__construct($name);
         $this->lockFactory = $lockFactory;
+        $this->exportService = $exportService;
     }
 
     protected function configure()
@@ -63,8 +66,7 @@ class ExportCommand extends AbstractCommand
         }
 
         $this->initProcessManager($input->getOption('monitoring-item-id'), ['autoCreate' => true, 'name' => $input->getOption('config-name')]);
-        $service = new ExportService();
-        $service->executeExport($input->getOption('config-name'));
+        $this->exportService->executeExport($input->getOption('config-name'));
 
         if (!$monitoringItemId) {
             $lock->release();

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -20,10 +20,10 @@ use Pimcore\Bundle\AdminBundle\Security\CsrfProtectionHandler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use \Pimcore\Bundle\AdminBundle\Controller\AdminController as PimcoreAdminController;
+use Pimcore\Controller\UserAwareController;
 
 #[Route('/admin/elementsexporttoolkit/admin')]
-class AdminController extends PimcoreAdminController
+class AdminController extends UserAwareController
 {
 
     #[Route('/settings', methods: ['GET'], name: 'elementsexporttoolkit-admin-settings')]

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -19,8 +19,8 @@ use Elements\Bundle\ExportToolkitBundle\Configuration;
 use Elements\Bundle\ExportToolkitBundle\Configuration\Dao;
 use Elements\Bundle\ExportToolkitBundle\ExportService\IExecutor;
 use Elements\Bundle\ExportToolkitBundle\Helper;
-use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\Cache;
+use Pimcore\Bundle\AdminBundle\Controller\AdminAbstractController;
 use Pimcore\Logger;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -30,7 +30,7 @@ use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/admin/elementsexporttoolkit/config')]
-class ConfigController extends AdminController
+class ConfigController extends AdminAbstractController
 {
 
     public function upgradeAction()
@@ -266,7 +266,7 @@ class ConfigController extends AdminController
             throw new Exception('Name does not exist.');
         }
 
-        if ($configuration && isset($configuration->configuration->general->executor)) {
+        if ($configuration && !empty($configuration->configuration->general->executor)) {
             /** @var $className IExecutor */
             $className = $configuration->configuration->general->executor;
             $cli = $className::getCli($name, null);

--- a/src/ElementsExportToolkitBundle.php
+++ b/src/ElementsExportToolkitBundle.php
@@ -17,9 +17,18 @@ namespace Elements\Bundle\ExportToolkitBundle;
 
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
 use Pimcore\Extension\Bundle\Installer\InstallerInterface;
+use \Pimcore\Extension\Bundle\PimcoreBundleAdminClassicInterface;
+use Pimcore\Routing\RouteReferenceInterface;
+use Pimcore\Extension\Bundle\Traits\BundleAdminClassicTrait;
+use Pimcore\HttpKernel\Bundle\DependentBundleInterface;
+use Pimcore\Bundle\AdminBundle\PimcoreAdminBundle;
+use Pimcore\HttpKernel\BundleCollection\BundleCollection;
+use Pimcore\Extension\Bundle\Traits\PackageVersionTrait;
 
-class ElementsExportToolkitBundle extends AbstractPimcoreBundle
+class ElementsExportToolkitBundle extends AbstractPimcoreBundle implements PimcoreBundleAdminClassicInterface, DependentBundleInterface
 {
+    use PackageVersionTrait;
+    use BundleAdminClassicTrait;
 
     const BUNDLE_NAME = 'ElementsExportToolkitBundle';
 
@@ -41,12 +50,23 @@ class ElementsExportToolkitBundle extends AbstractPimcoreBundle
         ];
     }
 
+    public function getEditmodeJsPaths(): array
+    {
+        return [];
+    }
+
+
+    public function getEditmodeCssPaths(): array
+    {
+        return [];
+    }
+
     /**
      * If the bundle has an installation routine, an installer is responsible of handling installation related tasks
      *
      * @return InstallerInterface|null
      */
-    public function getInstaller()
+    public function getInstaller(): ?InstallerInterface
     {
         return new Installer();
     }
@@ -65,8 +85,13 @@ class ElementsExportToolkitBundle extends AbstractPimcoreBundle
         return 'elements/export-toolkit-bundle';
     }
 
-    public function getNiceName()
+    public function getNiceName(): string
     {
         return self::BUNDLE_NAME;
+    }
+
+    public static function registerDependentBundles(BundleCollection $collection): void
+    {
+        $collection->addBundle(new PimcoreAdminBundle(), 60);
     }
 }

--- a/src/ExportService/Worker.php
+++ b/src/ExportService/Worker.php
@@ -287,7 +287,7 @@ class Worker
     {
         if ($this->workerConfig->getConfiguration()->general->sqlCondition) {
             $list = $this->getObjectList();
-            $list->addConditionParam('o_id = ?', $object->getId());
+            $list->addConditionParam('id = ?', $object->getId());
 
             $idList = $list->loadIdList();
             if (empty($idList)) {

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -23,12 +23,12 @@ class Installer extends AbstractInstaller
     /**
      * {@inheritdoc}
      */
-    public function isInstalled()
+    public function isInstalled(): bool
     {
         return file_exists(Helper::getConfigFilePath());
     }
 
-    public function needsReloadAfterInstall()
+    public function needsReloadAfterInstall(): bool
     {
         return true;
     }
@@ -36,7 +36,7 @@ class Installer extends AbstractInstaller
     /**
      * {@inheritdoc}
      */
-    public function canBeInstalled()
+    public function canBeInstalled(): bool
     {
         return !$this->isInstalled();
     }
@@ -44,7 +44,7 @@ class Installer extends AbstractInstaller
     /**
      * {@inheritdoc}
      */
-    public function install()
+    public function install(): void
     {
         // create backend permission
         \Pimcore\Model\User\Permission\Definition::create('plugin_exporttoolkit_config');
@@ -57,6 +57,6 @@ class Installer extends AbstractInstaller
             File::putPhpFile(Helper::getConfigFilePath(), to_php_data_file_format($defaultConfig));
         }
 
-        return true;
+        parent::install();
     }
 }

--- a/src/Resources/config/pimcore/config.yaml
+++ b/src/Resources/config/pimcore/config.yaml
@@ -1,0 +1,9 @@
+monolog:
+    handlers:
+        export_toolkit_log_handler:
+            level:    debug
+            type:     stream
+            path:     '%kernel.logs_dir%/export-toolkit.log'
+            channels: [export_toolkit]
+    channels: [export_toolkit]
+

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -3,6 +3,9 @@ services:
         autowire: true
         autoconfigure: true
 
+    export_toolkit.logger:
+        alias: monolog.logger.export_toolkit
+
     exporttoolkit.event_listener:
         class: Elements\Bundle\ExportToolkitBundle\EventListener\ExportListener
 #        lazy: true
@@ -13,11 +16,16 @@ services:
 
     exporttoolkit.exportservice:
         class: Elements\Bundle\ExportToolkitBundle\ExportService
+        calls:
+            - [setLogger, ['@export_toolkit.logger']]
 
     Elements\Bundle\ExportToolkitBundle\Command\:
         resource: '../../Command'
+        arguments:
+            $exportService: '@exporttoolkit.exportservice'
 
     Elements\Bundle\ExportToolkitBundle\Controller\:
         resource: '../../Controller'
         public: true
         tags: ['controller.service_arguments']
+

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -19,6 +19,9 @@ services:
         calls:
             - [setLogger, ['@export_toolkit.logger']]
 
+    Elements\Bundle\ExportToolkitBundle\ExportService:
+        alias: "@exporttoolkit.exportservice"
+
     Elements\Bundle\ExportToolkitBundle\Command\:
         resource: '../../Command'
         arguments:

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -8,7 +8,6 @@ services:
 
     exporttoolkit.event_listener:
         class: Elements\Bundle\ExportToolkitBundle\EventListener\ExportListener
-#        lazy: true
         arguments:
             - "@exporttoolkit.exportservice"
         tags:
@@ -16,6 +15,7 @@ services:
 
     exporttoolkit.exportservice:
         class: Elements\Bundle\ExportToolkitBundle\ExportService
+        lazy: true
         calls:
             - [setLogger, ['@export_toolkit.logger']]
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -20,7 +20,7 @@ services:
             - [setLogger, ['@export_toolkit.logger']]
 
     Elements\Bundle\ExportToolkitBundle\ExportService:
-        alias: "@exporttoolkit.exportservice"
+        alias: "exporttoolkit.exportservice"
 
     Elements\Bundle\ExportToolkitBundle\Command\:
         resource: '../../Command'

--- a/src/Resources/public/js/Plugin.js
+++ b/src/Resources/public/js/Plugin.js
@@ -16,7 +16,7 @@
 
 pimcore.registerNS("pimcore.plugin.outputDataConfigToolkit.Plugin");
 
-pimcore.plugin.outputDataConfigToolkit.Plugin = Class.create(pimcore.plugin.admin, {
+pimcore.plugin.outputDataConfigToolkit.Plugin = Class.create({
 
 
     getClassName: function () {
@@ -24,7 +24,6 @@ pimcore.plugin.outputDataConfigToolkit.Plugin = Class.create(pimcore.plugin.admi
     },
 
     initialize: function() {
-        pimcore.plugin.broker.registerPlugin(this);
     },
 
 

--- a/src/Resources/public/js/startup.js
+++ b/src/Resources/public/js/startup.js
@@ -8,16 +8,6 @@ pimcore.plugin.ExportToolkit = Class.create({
     initialize: function() {
         if (pimcore.events.preMenuBuild) {
             document.addEventListener(pimcore.events.preMenuBuild, this.preMenuBuild.bind(this));
-        } else {
-            document.addEventListener(pimcore.events.pimcoreReady, this.pimcoreReady.bind(this));
-        }
-
-    },
- 
-    pimcoreReady: function (params,broker){
-        if(pimcore.globalmanager.get("user").isAllowed("plugin_exporttoolkit_config")) {
-
-
         }
 
     },
@@ -52,21 +42,12 @@ pimcore.plugin.ExportToolkit = Class.create({
     },
 
     initMenu: function() {
-        var user = pimcore.globalmanager.get('user');
-
         // add to menu
-
-        var menuOptions = pimcore.settings.cmf.shortcutFilterDefinitions.length ? {
-            cls: "pimcore_navigation_flyout",
-            shadow: false,
-            items: []
-        } : null;
-
         let cacheClearMenuItem =  {
             text: t('plugin_exporttoolkit_clear_config_cache'),
             iconCls: 'plugin_exporttoolkit_clear_config_cache',
             hideOnClick: true,
-            menu: menuOptions,
+            menu: null,
             handler: function () {
                 Ext.Ajax.request({
                     url: '/admin/elementsexporttoolkit/config/clear-cache'
@@ -78,7 +59,7 @@ pimcore.plugin.ExportToolkit = Class.create({
             text: t('plugin_exporttoolkit_configpanel'),
             iconCls: 'plugin_exporttoolkit_configpanel',
             hideOnClick: true,
-            menu: menuOptions,
+            menu: null,
             handler: function () {
                 try {
                     pimcore.globalmanager.get("plugin_exporttoolkit_configpanel").activate();


### PR DESCRIPTION
- Adds support for Pimcore 11
  - Uses new JS events to render menu items
  - Started using dependency injection for monolog handle because `Simple::log` was removed
  - The ExportCommand now receives the ExportService in the constructor instead of creating a new object